### PR TITLE
mouse: fix single right click recognized as wheelzoom when using Macbook and Chrome

### DIFF
--- a/my-mind.js
+++ b/my-mind.js
@@ -4783,12 +4783,12 @@ MM.Mouse.handleEvent = function(e) {
 			if (MM.App.editing && item == MM.App.current) { return; } /* ignore on edited node */
 			if (item) { MM.App.select(item); }
 		break;
-		
+
 		case "dblclick":
 			var item = MM.App.map.getItemFor(e.target);
 			if (item) { MM.Command.Edit.execute(); }
 		break;
-		
+
 		case "contextmenu":
 			this._endDrag();
 			e.preventDefault();
@@ -4811,9 +4811,9 @@ MM.Mouse.handleEvent = function(e) {
 			}
 
 			if (e.type == "mousedown") { e.preventDefault(); } /* to prevent blurring the clipboard node */
-	
+
 			if (e.type == "touchstart") { /* context menu here, after we have the item */
-				this._touchTimeout = setTimeout(function() { 
+				this._touchTimeout = setTimeout(function() {
 					item && MM.App.select(item);
 					MM.Menu.open(e.clientX, e.clientY);
 				}, this.TOUCH_DELAY);
@@ -4821,7 +4821,7 @@ MM.Mouse.handleEvent = function(e) {
 
 			this._startDrag(e, item);
 		break;
-		
+
 		case "touchmove":
 			if (e.touches.length > 1) { return; }
 			e.clientX = e.touches[0].clientX;
@@ -4830,7 +4830,7 @@ MM.Mouse.handleEvent = function(e) {
 		case "mousemove":
 			this._processDrag(e);
 		break;
-		
+
 		case "touchend":
 			clearTimeout(this._touchTimeout);
 		case "mouseup":
@@ -4839,10 +4839,24 @@ MM.Mouse.handleEvent = function(e) {
 
 		case "wheel":
 		case "mousewheel":
-			var dir = 1;
-			if (e.wheelDelta && e.wheelDelta < 0) { dir = -1; }
-			if (e.deltaY && e.deltaY > 0) { dir = -1; }
-			MM.App.adjustFontSize(dir);
+			var dir = 0;
+			if (e.wheelDelta) {
+				if (e.wheelDelta < 0) {
+					dir = -1;
+				} else if (e.wheelDelta > 0) {
+					dir = 1;
+				}
+			}
+			if (e.deltaY) {
+				if (e.deltaY > 0) {
+					dir = -1;
+				} else if (e.deltaY < 0) {
+					dir = 1;
+				}
+			}
+			if (dir) {
+				MM.App.adjustFontSize(dir);
+			}
 		break;
 	}
 }
@@ -4861,7 +4875,7 @@ MM.Mouse._startDrag = function(e, item) {
 	this._cursor[0] = e.clientX;
 	this._cursor[1] = e.clientY;
 
-	if (item && !item.isRoot()) { 
+	if (item && !item.isRoot()) {
 		this._mode = "drag";
 		this._item = item;
 	} else {
@@ -4879,9 +4893,9 @@ MM.Mouse._processDrag = function(e) {
 
 	switch (this._mode) {
 		case "drag":
-			if (!this._ghost) { 
+			if (!this._ghost) {
 				this._port.style.cursor = "move";
-				this._buildGhost(dx, dy); 
+				this._buildGhost(dx, dy);
 			}
 			this._moveGhost(dx, dy);
 			var state = this._computeDragState();
@@ -4972,7 +4986,7 @@ MM.Mouse._computeDragState = function() {
 		if (tmp == this._item) { return state; } /* drop on a child or self */
 		tmp = tmp.getParent();
 	}
-	
+
 	var w1 = this._item.getDOM().content.offsetWidth;
 	var w2 = target.getDOM().content.offsetWidth;
 	var w = Math.max(w1, w2);

--- a/src/mouse.js
+++ b/src/mouse.js
@@ -28,12 +28,12 @@ MM.Mouse.handleEvent = function(e) {
 			if (MM.App.editing && item == MM.App.current) { return; } /* ignore on edited node */
 			if (item) { MM.App.select(item); }
 		break;
-		
+
 		case "dblclick":
 			var item = MM.App.map.getItemFor(e.target);
 			if (item) { MM.Command.Edit.execute(); }
 		break;
-		
+
 		case "contextmenu":
 			this._endDrag();
 			e.preventDefault();
@@ -56,9 +56,9 @@ MM.Mouse.handleEvent = function(e) {
 			}
 
 			if (e.type == "mousedown") { e.preventDefault(); } /* to prevent blurring the clipboard node */
-	
+
 			if (e.type == "touchstart") { /* context menu here, after we have the item */
-				this._touchTimeout = setTimeout(function() { 
+				this._touchTimeout = setTimeout(function() {
 					item && MM.App.select(item);
 					MM.Menu.open(e.clientX, e.clientY);
 				}, this.TOUCH_DELAY);
@@ -66,7 +66,7 @@ MM.Mouse.handleEvent = function(e) {
 
 			this._startDrag(e, item);
 		break;
-		
+
 		case "touchmove":
 			if (e.touches.length > 1) { return; }
 			e.clientX = e.touches[0].clientX;
@@ -75,7 +75,7 @@ MM.Mouse.handleEvent = function(e) {
 		case "mousemove":
 			this._processDrag(e);
 		break;
-		
+
 		case "touchend":
 			clearTimeout(this._touchTimeout);
 		case "mouseup":
@@ -84,10 +84,24 @@ MM.Mouse.handleEvent = function(e) {
 
 		case "wheel":
 		case "mousewheel":
-			var dir = 1;
-			if (e.wheelDelta && e.wheelDelta < 0) { dir = -1; }
-			if (e.deltaY && e.deltaY > 0) { dir = -1; }
-			MM.App.adjustFontSize(dir);
+			var dir = 0;
+			if (e.wheelDelta) {
+				if (e.wheelDelta < 0) {
+					dir = -1;
+				} else if (e.wheelDelta > 0) {
+					dir = 1;
+				}
+			}
+			if (e.deltaY) {
+				if (e.deltaY > 0) {
+					dir = -1;
+				} else if (e.deltaY < 0) {
+					dir = 1;
+				}
+			}
+			if (dir) {
+				MM.App.adjustFontSize(dir);
+			}
 		break;
 	}
 }
@@ -106,7 +120,7 @@ MM.Mouse._startDrag = function(e, item) {
 	this._cursor[0] = e.clientX;
 	this._cursor[1] = e.clientY;
 
-	if (item && !item.isRoot()) { 
+	if (item && !item.isRoot()) {
 		this._mode = "drag";
 		this._item = item;
 	} else {
@@ -124,9 +138,9 @@ MM.Mouse._processDrag = function(e) {
 
 	switch (this._mode) {
 		case "drag":
-			if (!this._ghost) { 
+			if (!this._ghost) {
 				this._port.style.cursor = "move";
-				this._buildGhost(dx, dy); 
+				this._buildGhost(dx, dy);
 			}
 			this._moveGhost(dx, dy);
 			var state = this._computeDragState();
@@ -217,7 +231,7 @@ MM.Mouse._computeDragState = function() {
 		if (tmp == this._item) { return state; } /* drop on a child or self */
 		tmp = tmp.getParent();
 	}
-	
+
 	var w1 = this._item.getDOM().content.offsetWidth;
 	var w2 = target.getDOM().content.offsetWidth;
 	var w = Math.max(w1, w2);


### PR DESCRIPTION
When right click with two fingers using Macbook's trackpad in Google Chrome browser, expect context menu but map zoomed in also.