### PR TITLE
Fix IO Error: Undefined when opening Google Drive files

### DIFF
--- a/my-mind.js
+++ b/my-mind.js
@@ -3741,9 +3741,9 @@ MM.Backend.GDrive._load = function(id) {
 	});
 
 	request.execute(function(response) {
-		if (response && response.downloadUrl) {
+		if (response && response.id) {
 			var xhr = new XMLHttpRequest();
-			xhr.open("get", response.downloadUrl, true);
+			xhr.open("get", "https://www.googleapis.com/drive/v2/files/" + response.id + '?alt=media', true);
 			xhr.setRequestHeader("Authorization", "Bearer " + gapi.auth.getToken().access_token);
 			Promise.send(xhr).then(
 				function(xhr) { promise.fulfill({data:xhr.responseText, name:response.title, mime:response.mimeType}); },

--- a/src/backend.gdrive.js
+++ b/src/backend.gdrive.js
@@ -81,9 +81,9 @@ MM.Backend.GDrive._load = function(id) {
 	});
 
 	request.execute(function(response) {
-		if (response && response.downloadUrl) {
+		if (response && response.id) {
 			var xhr = new XMLHttpRequest();
-			xhr.open("get", response.downloadUrl, true);
+			xhr.open("get", "https://www.googleapis.com/drive/v2/files/" + response.id + '?alt=media', true);
 			xhr.setRequestHeader("Authorization", "Bearer " + gapi.auth.getToken().access_token);
 			Promise.send(xhr).then(
 				function(xhr) { promise.fulfill({data:xhr.responseText, name:response.title, mime:response.mimeType}); },


### PR DESCRIPTION
Trying to read a Google Drive file gives a popup alert "IO Error: undefined", with `mymind` connected to the account. File sharing settings didn't make a difference, global or not; opening from gdrive with `mymind` gives the same error

The detailed response is `lockedDomainCreationFailure | The OAuth token was received in the query string, which this API forbids for response formats other than JSON or XML. If possible, try sending the OAuth token in the Authorization header instead.` . The auth token is already in the header though. 

Found the fix here https://stackoverflow.com/questions/60389531/cors-error-when-trying-to-open-files-from-google-drive-v2-api

would be happy to know if this can be solved properly in other ways. thanks for the great tool

