### PR TITLE
Fix compilation error that blob can be null

### DIFF
--- a/src/backend/image.ts
+++ b/src/backend/image.ts
@@ -27,8 +27,14 @@ export default class ImageBackend extends Backend {
 				canvas.height = img.height;
 				canvas.getContext("2d")!.drawImage(img, 0, 0);
 
-				return new Promise(resolve => {
-					canvas.toBlob(blob => resolve(URL.createObjectURL(blob)), "image/png");
+				return new Promise((resolve, reject) => {
+					canvas.toBlob(blob => {
+						if (blob) {
+							resolve(URL.createObjectURL(blob));
+						} else {
+							reject("Failed to create blob from canvas.");
+						}
+					}, "image/png");
 				});
 			break;
 		}


### PR DESCRIPTION
Compilation error was:

```
src/backend/image.ts:31:56 - error TS2345: Argument of type 'Blob | null' is not assignable to parameter of type 'Blob | MediaSource'.
  Type 'null' is not assignable to type 'Blob | MediaSource'.

31      canvas.toBlob(blob => resolve(URL.createObjectURL(blob)), "image/png");
                                                          ~~~~


Found 1 error in src/backend/image.ts:31
```